### PR TITLE
Update GitHub Actions to Latest Versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     name: Actions - clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - uses: actions-rs/toolchain@v1
@@ -26,7 +26,7 @@ jobs:
     name: Actions - rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - uses: actions-rs/toolchain@v1
@@ -44,7 +44,7 @@ jobs:
       matrix:
         os: [macOS-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
Changes
actions/checkout@v1 → actions/checkout@v4

Release Notes
https://github.com/actions/checkout/releases/tag/v4.2.2
